### PR TITLE
Configure GitHub OIDC deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
+    env:
+      AWS_REGION: us-east-1
+      AWS_DEPLOY_ROLE_ARN: arn:aws:iam::957356740227:role/GitHubActionsMcAdamsDevelopmentDeploy
+      AWS_S3_BUCKET: mcadamsdevelopment.com
+      AWS_CLOUDFRONT_DISTRIBUTION_ID: E98W2XOCHJ9W5
     defaults:
       run:
         working-directory: client
@@ -26,24 +31,24 @@ jobs:
       - run: npm ci
       - run: npm run check
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
-          aws-region: us-east-1
+          role-to-assume: ${{ env.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
       - name: Upload immutable assets
         run: >-
-          aws s3 sync build/client s3://${{ secrets.AWS_S3_BUCKET }}/
+          aws s3 sync build/client s3://${{ env.AWS_S3_BUCKET }}/
           --delete
           --exclude "*"
           --include "assets/*"
           --cache-control "public,max-age=31536000,immutable"
       - name: Upload HTML and crawler resources
         run: >-
-          aws s3 sync build/client s3://${{ secrets.AWS_S3_BUCKET }}/
+          aws s3 sync build/client s3://${{ env.AWS_S3_BUCKET }}/
           --exclude "assets/*"
           --cache-control "public,max-age=0,s-maxage=300,stale-while-revalidate=86400"
       - name: Invalidate mutable CloudFront documents
         run: >-
           aws cloudfront create-invalidation
-          --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
+          --distribution-id ${{ env.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
           --paths "/" "/*.html" "/robots.txt" "/sitemap.xml" "/llms.txt" "/404.html"

--- a/README.md
+++ b/README.md
@@ -77,17 +77,23 @@ than introducing another manually maintained route list.
 
 ## AWS deployment
 
-GitHub Actions verifies each change and can deploy from `master`. Configure the
-following GitHub secrets before enabling production deployment:
+GitHub Actions verifies each change and deploys pushes to `master` using GitHub
+OIDC. It does not use stored AWS access keys, GitHub secrets, or GitHub Actions
+variables. The non-sensitive deployment identifiers (region, role ARN, S3
+bucket, and CloudFront distribution ID) are committed in
+`.github/workflows/deploy.yml`.
 
-- `AWS_DEPLOY_ROLE_ARN`
-- `AWS_S3_BUCKET`
-- `AWS_CLOUDFRONT_DISTRIBUTION_ID`
+The production job can assume only
+`GitHubActionsMcAdamsDevelopmentDeploy`. Its trust policy limits access to this
+repository's `production` environment; its inline permissions are limited to
+deploying `mcadamsdevelopment.com` and invalidating the site's CloudFront
+distribution. The checked-in policy documents are:
 
-The role must use GitHub OIDC and be limited to the target bucket and
-distribution. See [AWS deployment notes](aws-config/README.md) for the required
-CloudFront Function, private-origin migration, cache policy, and real-404
-configuration.
+- [OIDC trust policy](aws-config/github-actions-oidc-trust-policy.json)
+- [deployment permissions policy](aws-config/github-actions-deploy-policy.json)
+
+See [AWS deployment notes](aws-config/README.md) for the required CloudFront
+Function, private-origin migration, cache policy, and real-404 configuration.
 
 ## Cache behavior
 

--- a/aws-config/github-actions-deploy-policy.json
+++ b/aws-config/github-actions-deploy-policy.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ListDeploymentBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::mcadamsdevelopment.com"
+    },
+    {
+      "Sid": "DeployStaticSiteObjects",
+      "Effect": "Allow",
+      "Action": [
+        "s3:DeleteObject",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::mcadamsdevelopment.com/*"
+    },
+    {
+      "Sid": "InvalidateSiteDistribution",
+      "Effect": "Allow",
+      "Action": "cloudfront:CreateInvalidation",
+      "Resource": "arn:aws:cloudfront::957356740227:distribution/E98W2XOCHJ9W5"
+    }
+  ]
+}

--- a/aws-config/github-actions-oidc-trust-policy.json
+++ b/aws-config/github-actions-oidc-trust-policy.json
@@ -1,0 +1,19 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowGitHubActionsProductionDeployments",
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::957356740227:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:imcadams/mcadams-development:environment:production"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a least-privilege GitHub OIDC deployment role configuration for the existing S3 bucket and CloudFront distribution
- remove GitHub secret and variable requirements by committing non-sensitive deployment identifiers
- upgrade AWS credential configuration to v5
- document the zero-secret deployment model and checked-in IAM policies

## Validation
- validated both IAM policy JSON documents
- ran git diff --check