### PR TITLE
Document canonical CloudFront redirect

### DIFF
--- a/aws-config/README.md
+++ b/aws-config/README.md
@@ -14,8 +14,9 @@ server-side configuration. See `docs/hvac-landing-page-and-contact-spam-plan.md`
 for the complete contract and rollout sequence.
 ## Required distribution changes
 
-1. Create or reuse a CloudFront Function from `cloudfront-function.js` and
-   associate it with the viewer-request event on the default behavior.
+1. Publish `cloudfront-function.js` as the `mcadams-development-canonical-host`
+   CloudFront Function and associate its `LIVE` version with the viewer-request
+   event on the default behavior.
 2. Set `www.mcadamsdevelopment.com` as the canonical host in the function.
 3. Change the origin from the S3 website endpoint to the bucket REST endpoint.
 4. Create an Origin Access Control, attach it to that origin, and block all
@@ -28,8 +29,11 @@ for the complete contract and rollout sequence.
    policy after validating it in report-only mode.
 
 The function maps `/about` to `/about/index.html`, redirects the apex hostname
-to `www`, and normalizes trailing slashes. It deliberately does not map unknown
-routes to the home page; S3/CloudFront can return a real 404 for them.
+to `www` while preserving the path and query string, and normalizes trailing
+slashes. It deliberately does not map unknown routes to the home page;
+S3/CloudFront can return a real 404 for them. The normal static-site deployment
+workflow only uploads site assets and invalidates CloudFront; publish or update
+this function as a separate CloudFront infrastructure operation.
 
 ## Cache headers
 

--- a/aws-config/cloudfront-function.js
+++ b/aws-config/cloudfront-function.js
@@ -4,12 +4,36 @@ function handler(event) {
   var canonicalHost = 'www.mcadamsdevelopment.com';
   var host = headers.host && headers.host.value;
 
+  function querySuffix(querystring) {
+    var parts = [];
+
+    for (var key in querystring) {
+      if (!Object.prototype.hasOwnProperty.call(querystring, key)) {
+        continue;
+      }
+
+      var parameter = querystring[key];
+      if (parameter.multiValue) {
+        for (var i = 0; i < parameter.multiValue.length; i++) {
+          var value = parameter.multiValue[i].value;
+          parts.push(key + (value ? '=' + value : ''));
+        }
+      } else {
+        parts.push(key + (parameter.value ? '=' + parameter.value : ''));
+      }
+    }
+
+    return parts.length ? '?' + parts.join('&') : '';
+  }
+
+  var query = querySuffix(request.querystring);
+
   if (host && host !== canonicalHost) {
     return {
       statusCode: 301,
       statusDescription: 'Moved Permanently',
       headers: {
-        location: { value: 'https://' + canonicalHost + request.uri },
+        location: { value: 'https://' + canonicalHost + request.uri + query },
       },
     };
   }
@@ -25,7 +49,7 @@ function handler(event) {
       statusCode: 301,
       statusDescription: 'Moved Permanently',
       headers: {
-        location: { value: 'https://' + canonicalHost + uri.slice(0, -1) },
+        location: { value: 'https://' + canonicalHost + uri.slice(0, -1) + query },
       },
     };
   }


### PR DESCRIPTION
## Summary
- preserve query strings when CloudFront redirects the apex hostname or normalizes a trailing slash
- document the published canonical-host function and clarify that it is separate from static asset deployment

## Deployment
- published mcadams-development-canonical-host and attached its LIVE version to the viewer-request event on distribution E98W2XOCHJ9W5